### PR TITLE
refactor: Use reqwest to replace isahc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,11 @@ serde_yaml = "0.9.21"
 clap = {version = "4.3.8", features = ["derive", "cargo"]}
 thiserror = "1.0.40"
 rand = "0.8.5"
-isahc = "1.7"
+reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls"] }
 phf = { version = "0.11", features = ["macros"] }
 # linked list to store the containers in the order they appear in the docker-compose.yaml
 indexmap = { version = "2.0.0", features = ["serde"] }
-
-# https://github.com/sfackler/rust-openssl/issues/1021
-openssl = { version = "0.10", features = ["vendored"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [profile.release]
 debug = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,8 @@ struct RectangleStruct {
     pub bound_elements: Vec<BoundElement>,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
     let excalidraw_config: ExcalidrawConfig =
         file_utils::get_excalidraw_config(cli.config_path.as_str());
@@ -164,7 +165,7 @@ fn main() {
 
     let input_path = &cli.input_path.unwrap();
     let input_filepath = input_path.as_str();
-    let docker_compose_yaml = file_utils::get_docker_compose_content(input_filepath);
+    let docker_compose_yaml = file_utils::get_docker_compose_content(input_filepath).await;
 
     let alignment_mode = excalidraw_config.alignment.mode.as_str();
     let (x_margin, y_margin, x_alignment_factor, y_alignment_factor) = margins(alignment_mode);


### PR DESCRIPTION
Part of https://github.com/etolbakov/excalidocker-rs/issues/31

We replace isahc and openssl with reqwest and then try build on wasm.